### PR TITLE
PNRG seeding improvement

### DIFF
--- a/src/utility/trezor/rand.c
+++ b/src/utility/trezor/rand.c
@@ -96,27 +96,27 @@ static void init_ram_seed() {
 	// obtain some entropy from uninitialized heap memory
 	uint8_t * uninitialized_heap = (uint8_t *)malloc(UNINITIALIZED_ENTROPY_SIZE);
 	if (uninitialized_heap == NULL) {
-		return;
+		while(1){}; // non recoverable error
 	}
 	
 	// fail if stack or heap are zero-filled
 	if (is_zero_filled(uninitialized_stack_entropy)) {
 	    //printf("FAIL: Uninitialized stack is zero-filled\n");
-	    return;
+	    while(1){}; // non recoverable error
 	}
 	if (is_zero_filled(uninitialized_heap)) {
 	    //printf("FAIL: Uninitialized heap is zero-filled\n");
-	    return;
+	    while(1){}; // non recoverable error
 	}
 	
 	// fail if stack or heap are 32bit pattern-filled
 	if (is_pattern_filled((uint32_t *)uninitialized_stack_entropy)) {
 	    //printf("FAIL: Uninitialized stack is pattern-filled\n");
-	    return;
+	    while(1){}; // non recoverable error
 	}
 	if (is_pattern_filled((uint32_t *)uninitialized_heap)) {
 	    //printf("FAIL: Uninitialized heap is pattern-filled\n");
-	    return;
+	    while(1){}; // non recoverable error
 	}
 	
 	// SHA256(Uninitialized heap | Uninitialized stack)


### PR DESCRIPTION
The purpose of this commit is:
1) warn users with pragma message to avoid using those functions in production
2) add uninitialized stack (together as the previous uninitialized heap) as extra entropy source (because while testing some embedded devices the heap allocations are often zero-filled and I was often getting the same private keys, so the current implementation is EXTREMELY unsafe)
3) double check if heap and stack are truly uninitialized (zero-fill and pattern checks), some compilers might initialized stack variables automatically (e.g. Clang with -ftrivial-auto-var-init), so fail seed initialization in that case.
4) is seeding fails, loop forever, do not generate any random

Seed init is still garbage and a TRNG should be used, but at least it's a (tiny) bit less unsafe.

About the old line:
  memcpy(arr, hash, 32); // to maintain previous entropy, kinda
This doesn't make any sense, since
  static uint8_t hash[32];
will be always inizialized to zero, so this memcpy only zero-fills the first 32 bytes which obviously reduces the entropy and it's pretty much useless and I removed it.