### PR TITLE
include esp_system and declare esp_random in src/utiltiy/trezor/rand.c

### DIFF
--- a/src/utility/trezor/rand.c
+++ b/src/utility/trezor/rand.c
@@ -26,6 +26,8 @@
 #include "rand.h"
 #include "sha2.h"
 #include <string.h>
+#include esp_system.h
+extern uint32_t esp_random(void);
 
 // esp boards
 #if defined(ESP_PLATFORM)


### PR DESCRIPTION
This change was added due to users reporting an error during the build of an Arduino hardware wallet. Thanks.